### PR TITLE
Add a dockerfile for running datasette with the rental registry database

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM python:3.11-slim-buster
+
+# Install poetry
+RUN pip install poetry==1.4.2
+
+ENV POETRY_NO_INTERACTION=1 \
+  POETRY_VIRTUALENVS_IN_PROJECT=1 \
+  POETRY_VIRTUALENVS_CREATE=1 \
+  POETRY_CACHE_DIR=/tmp/poetry_cache \
+  PATH="/app/.venv/bin:$PATH"
+
+WORKDIR /app
+
+# Install the dependencies
+COPY pyproject.toml poetry.lock ./
+RUN poetry install --without dev --no-root && rm -rf $POETRY_CACHE_DIR
+
+# Run the spider to generate the output.db file
+COPY rental_registry rental_registry
+COPY scrapy.cfg scrapy.cfg
+RUN scrapy crawl rental_registry -o output.db
+
+ENV PORT=8000
+EXPOSE $PORT
+
+# Run the datasette server
+# --cors allows frontend access from across domains
+# -i opens the file in immutable mode
+ENTRYPOINT datasette -h 0.0.0.0 -p $PORT --cors -i output.db

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # Property Owner Accountability
+
 Mapping properties on the Montgomery County Rental Registry
 
 ## Scrapy
@@ -27,3 +28,14 @@ Alternatively, you can output to a jsonl file for quicker reading:
 ```console
 $ scrapy crawl rental_registry -o output.jsonl
 ```
+
+## Docker & Datasette
+
+The Dockerfile in this repo wraps up both the scraping and the datasette server. To build and run a container:
+
+```console
+$ docker build -t rental_registry .
+$ docker run -it --rm -p 8000:8000 rental_registry
+```
+
+After running, you can access the datasette server running on your local computer at http://localhost:8000


### PR DESCRIPTION
This change provides a Dockerfile that wraps up the scraping and datasette together. The image build process is where the rental registry is scraped and bakes the data into the resulting image.

Try it out with these commands:
```console
$ docker build -t rental_registry .
$ docker run -it --rm -p 8000:8000 rental_registry
```
